### PR TITLE
fix: #65 paragraphs getter 제거

### DIFF
--- a/slap-saver/controllers/articleController.js
+++ b/slap-saver/controllers/articleController.js
@@ -13,6 +13,7 @@ module.exports = {
     // const author = await article.getAuthor();
     article.authorImg = `/images/authorImages/${article.Author.photo}`;
     article.image = `/images/articleImages/${article.image}`;
+    article.paragraphs = JSON.parse(article.paragraphs);
     article.dataValues.updatedAt = moment(article.updatedAt).format('YYYY.MM.DD HH:mm:ss');
     res.render('articles/article', { article });
   },

--- a/slap-saver/controllers/authorController.js
+++ b/slap-saver/controllers/authorController.js
@@ -213,10 +213,11 @@ module.exports = {
     Article.findOne({ where: { id: req.params.articleId } })
       .then((article) => {
         article.image = `/images/articleImages/${article.image}`;
+        const paragraphs = JSON.parse(article.paragraphs).paragraphs;
         return res.render('author/editArticle', {
           title: '기사 수정 페이지',
           article: article,
-          paragraphs: article.paragraphs['paragraphs'],
+          paragraphs,
         });
       })
       .catch((err) => console.log(err));

--- a/slap-saver/models/article.js
+++ b/slap-saver/models/article.js
@@ -69,13 +69,6 @@ module.exports = (sequelize, DataTypes) => {
       },
       paragraphs: {
         type: DataTypes.JSON,
-        get() {
-          if (this.getDataValue('paragraphs')) {
-            return JSON.parse(this.getDataValue('paragraphs'));
-          } else {
-            return this.getDataValue('paragraphs');
-          }
-        }
       },
       createdAt: {
         allowNull: false,

--- a/slap-saver/views/articles/article.ejs
+++ b/slap-saver/views/articles/article.ejs
@@ -47,7 +47,7 @@
   <section class="detail">
     <article class="detail__article">
       <article class="detail-sections" style="display: none;">
-        <% article.paragraphs['paragraphs'].forEach(element => { %>
+        <% article.paragraphs.paragraphs.forEach(element => { %>
           <h3><%= element[0] %> </h3>
           <p><%= element[1] %> </p>
         <% }) %>


### PR DESCRIPTION
# 개요
ec2에서 발생하던 에러를 제거했습니다.

# 작업사항
- 이전에 만들었던 paragraphs 의 getter 를 제거했습니다.
- paragraphs 를 사용하는  editArticle.ejs 와 article.ejs 에서 paragraphs의 존재 여부를 확인하고 `forEach` 를 사용하도록 수정했습니다.

# 참고사항
- ec2에서의 동작까지 확인을 마쳤습니다.
- 현재 ec2에서 실행되고 있는 앱의 브랜치가 `fix-paragraphs-ec2` 기 때문에 `saver.42seoul.io`에서 직접 테스트 해볼 수 있습니다.
